### PR TITLE
Use re-counting

### DIFF
--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -31,8 +31,8 @@ public class BWDBenchmark
     [Benchmark]
     public async Task Compress()
     {
-        var encodeTask = new BufferedFileSource("/home/mitiko/Documents/Projects/Compression/BWDPerf/data/enwik4", 10_000_000)
-            .ToCoder(new BWDEncoder(new Options(maxWordSize: 32, indexSize: 8), new NaiveRanking(8, 8, 32)))
+        var encodeTask = new BufferedFileSource("/home/mitiko/Documents/Projects/Compression/BWDPerf/data/enwik4", 1_000)
+            .ToCoder(new BWDEncoder(new Options(maxWordSize: 12, indexSize: 5), new NaiveRanking(8, 5, 12)))
             .ToCoder<BWDBlock, BWDBlock>(new MeasureEntropy())
             .ToCoder(new BlockToBytes())
             .Serialize(new SerializeToFile("encoded"));

--- a/examples/Program.cs
+++ b/examples/Program.cs
@@ -21,8 +21,13 @@ class Program
     {
         Console.WriteLine("Started");
         // BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        var timer = System.Diagnostics.Stopwatch.StartNew();
         await new BWDBenchmark().Compress();
+        Console.WriteLine($"Compression took: {timer.Elapsed}");
+        timer.Restart();
         await new BWDBenchmark().Decompress();
+        Console.WriteLine($"Decompression took: {timer.Elapsed}");
+
     }
 }
 
@@ -31,8 +36,9 @@ public class BWDBenchmark
     [Benchmark]
     public async Task Compress()
     {
-        var encodeTask = new BufferedFileSource("/home/mitiko/Documents/Projects/Compression/BWDPerf/data/enwik4", 1_000)
-            .ToCoder(new BWDEncoder(new Options(maxWordSize: 12, indexSize: 5), new NaiveRanking(8, 5, 12)))
+        var options = new Options(maxWordSize: 32);
+        var encodeTask = new BufferedFileSource("/home/mitiko/Documents/Projects/Compression/BWDPerf/data/enwik4", 1_000_000)
+            .ToCoder(new BWDEncoder(options, new NaiveRanking(options)))
             .ToCoder<BWDBlock, BWDBlock>(new MeasureEntropy())
             .ToCoder(new BlockToBytes())
             .Serialize(new SerializeToFile("encoded"));

--- a/src/Tools/LCPArray.cs
+++ b/src/Tools/LCPArray.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace BWDPerf.Tools
+{
+    public class LCPArray
+    {
+        private int[] LCP { get; }
+
+        public int this[int index] => this.LCP[index];
+        public int Length => this.LCP.Length;
+
+        public LCPArray(ReadOnlyMemory<byte> buffer, SuffixArray SA)
+        {
+            var T = buffer.Span;
+            int n = T.Length;
+            var Phi = new int[n];
+            var PLCP = new int[n];
+            this.LCP = new int[n-1];
+
+            for (int i = 1; i < n; i++)
+                Phi[SA[i]] = SA[i-1];
+
+            int l = 0;
+            for (int j = 0; j < n; j++)
+            {
+                while (true)
+                {
+                    var phi = Phi[j];
+                    if (j+l >= n) break;
+                    if (phi+l >= n) break;
+                    if (T[j+l] != T[phi+l]) break;
+                    l++;
+                }
+                PLCP[j] = l;
+                if (l > 0) l--;
+            }
+
+            for (int i = 0; i < n-1; i++)
+                this.LCP[i] = PLCP[SA[i+1]];
+        }
+    }
+}

--- a/src/Tools/LCPArray.cs
+++ b/src/Tools/LCPArray.cs
@@ -9,34 +9,38 @@ namespace BWDPerf.Tools
         public int this[int index] => this.LCP[index];
         public int Length => this.LCP.Length;
 
+        // kasai algorithm for LCP construction from SA in O(n)
         public LCPArray(ReadOnlyMemory<byte> buffer, SuffixArray SA)
         {
             var T = buffer.Span;
             int n = T.Length;
-            var Phi = new int[n];
-            var PLCP = new int[n];
-            this.LCP = new int[n-1];
+            LCP = new int[n-1];
 
-            for (int i = 1; i < n; i++)
-                Phi[SA[i]] = SA[i-1];
+            var SAinv = new int[n];
+            for (int i = 0; i < n; i++)
+                SAinv[SA[i]] = i;
 
-            int l = 0;
-            for (int j = 0; j < n; j++)
+            int k = 0;
+            for (int i = 0; i < n; i++)
             {
+                if (SAinv[i] == n-1)
+                {
+                    k = 0;
+                    continue;
+                }
+                int j = SA[SAinv[i]+1];
+
                 while (true)
                 {
-                    var phi = Phi[j];
-                    if (j+l >= n) break;
-                    if (phi+l >= n) break;
-                    if (T[j+l] != T[phi+l]) break;
-                    l++;
+                    if (i+k >= n) break;
+                    if (j+k >= n) break;
+                    if (T[i+k] != T[j+k]) break;
+                    k++;
                 }
-                PLCP[j] = l;
-                if (l > 0) l--;
-            }
 
-            for (int i = 0; i < n-1; i++)
-                this.LCP[i] = PLCP[SA[i+1]];
+                LCP[SAinv[i]] = k;
+                if (k > 0) k--;
+            }
         }
     }
 }

--- a/src/Tools/SuffixArray.cs
+++ b/src/Tools/SuffixArray.cs
@@ -4,7 +4,7 @@ namespace BWDPerf.Tools
 {
     public class SuffixArray
     {
-        public int[] SA { get; }
+        private int[] SA { get; }
 
         public int this[int index] => this.SA[index];
         public int Length => this.SA.Length;

--- a/src/Transforms/Algorithms/BWD/BWD.cs
+++ b/src/Transforms/Algorithms/BWD/BWD.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using BWDPerf.Interfaces;
 using BWDPerf.Tools;
+using BWDPerf.Transforms.Algorithms.BWD.Counting;
 using BWDPerf.Transforms.Algorithms.BWD.Entities;
 
 namespace BWDPerf.Transforms.Algorithms.BWD
@@ -10,6 +11,7 @@ namespace BWDPerf.Transforms.Algorithms.BWD
     {
         internal Options Options { get; }
         internal IBWDRanking Ranking { get; }
+        internal DynamicWordCounting WordCounter { get; } = new();
         internal SuffixArray SA { get; set; }
         internal BitVector BitVector { get; private set; }
 
@@ -21,18 +23,12 @@ namespace BWDPerf.Transforms.Algorithms.BWD
 
         internal BWDictionary CalculateDictionary(ReadOnlyMemory<byte> buffer)
         {
-            // Inspect all methods
-            // Select locations that need to be recounted
-            // Keep a bit vector of counted places
-            // When splitting, zero out the locations that need to be recounted
-            // Recount these locations until the bitvector is full
-
             var dictionary = new BWDictionary(this.Options.IndexSize);
 
             this.SA = new SuffixArray(buffer, this.Options.MaxWordSize); // O(b log m) construction
-            this.BitVector = new BitVector(buffer.Length, bit: true);
-            RankAllWords(buffer);
             // Initialize with all bits set
+            this.BitVector = new BitVector(buffer.Length, bit: true);
+            this.WordCounter.CountAllWords(buffer, this.SA, this.BitVector, this.Options.MaxWordSize);
 
             for (int i = 0; i < dictionary.Length; i++)
             {
@@ -45,10 +41,13 @@ namespace BWDPerf.Transforms.Algorithms.BWD
                     break;
                 }
 
-                RankAllWords(buffer);
+                foreach (var wordCount in this.WordCounter.Counts)
+                    this.Ranking.Rank(wordCount.Key, wordCount.Value);
+
                 var word = this.Ranking.GetTopRankedWords()[0].Word;
+                // Console.WriteLine($"Choosing word: ({word.Location}, {word.Length})");
                 dictionary[i] = buffer.Slice(word.Location, word.Length).ToArray();
-                SplitByWord(buffer, word);
+                this.WordCounter.RecountSelectedWord(word, buffer, this.SA, this.BitVector, this.Options.MaxWordSize);
 
                 // if there's no more words to encode, we're done
                 if (this.BitVector.IsEmpty())
@@ -56,71 +55,6 @@ namespace BWDPerf.Transforms.Algorithms.BWD
             }
 
             return dictionary;
-        }
-
-        internal void RankAllWords(ReadOnlyMemory<byte> buffer)
-        {
-            // This is basically analogous to constructing the LCP array over the suffix array
-            var matches = new List<int>[this.Options.MaxWordSize];
-            for (int i = 0; i < matches.Length; i++)
-                matches[i] = new List<int>();
-
-            for (int n = 0; n < this.SA.Length - 1; n++)
-            {
-                var curr = this.SA[n];
-                var next = this.SA[n+1];
-
-                // Matched
-                for (int k = 0; k < this.Options.MaxWordSize && curr + k < buffer.Length; k++)
-                    matches[k].Add(curr);
-
-                int matchLength = 0;
-                for (matchLength = 0; matchLength < this.Options.MaxWordSize; matchLength++)
-                {
-                    if (curr + matchLength >= buffer.Length || next + matchLength >= buffer.Length) break;
-                    if (buffer.Span[curr + matchLength] != buffer.Span[next + matchLength]) break;
-                }
-
-                // Not matched
-                for (int k = matchLength; k < this.Options.MaxWordSize; k++)
-                {
-                    if (matches[k].Count == 0) break;
-                    var (word, count) = CountWord(matches[k], k+1);
-                    this.Ranking.Rank(word, count);
-                    matches[k].Clear();
-                }
-            }
-            // Add matches of the last word
-            var last = this.SA[this.SA.Length - 1];
-            for (int k = 0; k < this.Options.MaxWordSize && last + k < buffer.Length; k++)
-                    matches[k].Add(last);
-            // Last word doesn't match anything
-            for (int k = 0; k < this.Options.MaxWordSize; k++)
-            {
-                if (matches[k].Count == 0) break;
-                var (word, count) = CountWord(matches[k], k+1);
-                this.Ranking.Rank(word, count);
-                matches[k].Clear();
-            }
-        }
-
-        internal void SplitByWord(ReadOnlyMemory<byte> buffer, Word word)
-        {
-            var locations = this.SA.Search(buffer, buffer.Slice(word.Location, word.Length));
-            for (int l = 0; l < locations.Length; l++)
-            {
-                var start = locations[l]; // start inclusive
-                var end = locations[l] + word.Length; // end exclusive
-
-                // Check location hasn't been used
-                bool available = true;
-                for (int s = start; s < end; s++)
-                    if (!this.BitVector[s]) { available = false; break; }
-                if (!available) continue;
-
-                for (int s = start; s < end; s++)
-                    this.BitVector[s] = false;
-            }
         }
 
         internal byte[] CollectSTokenData(ReadOnlyMemory<byte> buffer)
@@ -144,28 +78,6 @@ namespace BWDPerf.Transforms.Algorithms.BWD
                     stoken.Add(0xff);
             }
             return stoken.ToArray();
-        }
-
-        internal (Word word, int count) CountWord(List<int> matches, int length)
-        {
-            matches.Sort();
-            int curr = matches[0];
-            int count = 1;
-            foreach (var next in matches)
-            {
-                if (next >= curr + length)
-                {
-                    bool available = true;
-                    for (int i = 0; i < length; i++)
-                        if (!this.BitVector[next+i]) { available = false; break; }
-                    if (available)
-                    {
-                        curr = next;
-                        count++;
-                    }
-                }
-            }
-            return (new Word(curr, length), count);
         }
     }
 }

--- a/src/Transforms/Algorithms/BWD/BWD.cs
+++ b/src/Transforms/Algorithms/BWD/BWD.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using BWDPerf.Interfaces;
 using BWDPerf.Tools;
 using BWDPerf.Transforms.Algorithms.BWD.Counting;
@@ -23,61 +22,24 @@ namespace BWDPerf.Transforms.Algorithms.BWD
 
         internal BWDictionary CalculateDictionary(ReadOnlyMemory<byte> buffer)
         {
-            var dictionary = new BWDictionary(this.Options.IndexSize);
+            var dictionary = new BWDictionary();
 
-            this.SA = new SuffixArray(buffer, this.Options.MaxWordSize); // O(b log m) construction
-            // Initialize with all bits set
-            this.BitVector = new BitVector(buffer.Length, bit: true);
+            this.SA = new SuffixArray(buffer); // O(b log m) construction
+            this.BitVector = new BitVector(buffer.Length, bit: true); // initialize with all bits set
             this.WordCounter.CountAllWords(buffer, this.SA, this.BitVector, this.Options.MaxWordSize);
 
-            for (int i = 0; i < dictionary.Length; i++)
+            // if there's no more words to encode, we're done
+            for (int i = 0; !this.BitVector.IsEmpty(); i++)
             {
-                // The last word in the dictionary is always an <s> token
-                // If the words in the dictionary cover the whole buffer, there might not be an <s> token
-                // In future versions, we'll assume entropy coding is used after and the dictionary size won't be limited, rendering the need for stoken useless.
-                if (i == dictionary.STokenIndex)
-                {
-                    dictionary[i] = CollectSTokenData(buffer);
-                    break;
-                }
-
                 foreach (var wordCount in this.WordCounter.Counts)
                     this.Ranking.Rank(wordCount.Key, wordCount.Value);
 
                 var word = this.Ranking.GetTopRankedWords()[0].Word;
-                // Console.WriteLine($"Choosing word: ({word.Location}, {word.Length})");
                 dictionary[i] = buffer.Slice(word.Location, word.Length).ToArray();
                 this.WordCounter.RecountSelectedWord(word, buffer, this.SA, this.BitVector, this.Options.MaxWordSize);
-
-                // if there's no more words to encode, we're done
-                if (this.BitVector.IsEmpty())
-                    break;
             }
 
             return dictionary;
-        }
-
-        internal byte[] CollectSTokenData(ReadOnlyMemory<byte> buffer)
-        {
-            var stoken = new List<byte>();
-            for (int i = 0; i < this.BitVector.Length; i++)
-            {
-                bool readStoken = false;
-                while (this.BitVector[i])
-                {
-                    if (!readStoken) readStoken = true;
-                    // TODO: Add tests with 0xff
-                    if (buffer.Span[i] == 0xff)
-                        stoken.Add(0xff);
-                    stoken.Add(buffer.Span[i]);
-                    i++;
-                    if (i >= buffer.Length) break;
-                }
-
-                if (readStoken)
-                    stoken.Add(0xff);
-            }
-            return stoken.ToArray();
         }
     }
 }

--- a/src/Transforms/Algorithms/BWD/Counting/DynamicWordCounting.cs
+++ b/src/Transforms/Algorithms/BWD/Counting/DynamicWordCounting.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using BWDPerf.Tools;
+using BWDPerf.Transforms.Algorithms.BWD.Entities;
+
+namespace BWDPerf.Transforms.Algorithms.BWD.Counting
+{
+    public class DynamicWordCounting
+    {
+        public Dictionary<Word, int> Counts { get; set; } = new();
+
+        public void CountAllWords(ReadOnlyMemory<byte> buffer, SuffixArray SA, BitVector bitVector, int maxWordSize)
+        {
+            // This is basically analogous to constructing the LCP array over the suffix array
+            var matches = new List<int>[maxWordSize];
+            for (int i = 0; i < matches.Length; i++)
+                matches[i] = new List<int>();
+
+            for (int n = 0; n < SA.Length - 1; n++)
+            {
+                var curr = SA[n];
+                var next = SA[n+1];
+
+                // Matched
+                for (int k = 0; k < maxWordSize && curr + k < buffer.Length; k++)
+                    matches[k].Add(curr);
+
+                int matchLength = 0;
+                for (matchLength = 0; matchLength < maxWordSize; matchLength++)
+                {
+                    if (curr + matchLength >= buffer.Length || next + matchLength >= buffer.Length) break;
+                    if (buffer.Span[curr + matchLength] != buffer.Span[next + matchLength]) break;
+                }
+
+                // Not matched
+                for (int k = matchLength; k < maxWordSize; k++)
+                {
+                    if (matches[k].Count == 0) break;
+                    var (word, count) = CountWord(matches[k], k+1, bitVector);
+                    try
+                    {
+
+                        this.Counts.Add(word, count);
+                    }
+                    catch
+                    {
+                        Console.WriteLine($"word -> ({word.Location}, {word.Length})");
+                    }
+                    matches[k].Clear();
+                }
+            }
+            // Add matches of the last word
+            var last = SA[SA.Length - 1];
+            for (int k = 0; k < maxWordSize && last + k < buffer.Length; k++)
+                    matches[k].Add(last);
+
+            // Last word doesn't match anything, so start at matchLength = 0
+            for (int k = 0; k < maxWordSize; k++)
+            {
+                if (matches[k].Count == 0) break;
+                var (word, count) = CountWord(matches[k], k+1, bitVector);
+                this.Counts.Add(word, count);
+                matches[k].Clear();
+            }
+        }
+
+        public void RecountSelectedWord(Word word, ReadOnlyMemory<byte> buffer, SuffixArray SA, BitVector bitVector, int maxWordSize)
+        {
+            // Parse - get locations
+            // Get adjacent words
+            // Set bitvector to 0s for our word == splitting
+            // Count every word in the adjacent list and upate the dictionarys
+            var matches = SA.Search(buffer, buffer.Slice(word.Location, word.Length));
+            var locations = Parse(matches, word.Length, bitVector);
+            if (locations.Count == 0)
+            {
+                Console.WriteLine($"Matches: {matches.Length}");
+                Console.WriteLine($"word: ({word.Location}, {word.Length})");
+                Console.WriteLine($"Supposed count: {this.Counts[word]}");
+                throw new Exception("Trying to recount a word that doesn't exist");
+            }
+            var adjacentWords = new List<Word>();
+            var containedWords = new List<Word>();
+            int loc, endLoc;
+            for (int l = 0; l < locations.Count; l++)
+            {
+                loc = locations[l];
+                endLoc = locations[l] + word.Length - 1;
+
+                // Words before
+                for (int start = loc - maxWordSize + 1; start < loc; start++)
+                {
+                    if (start < 0) continue;
+                    for (int end = start + maxWordSize - 1; end >= loc; end--)
+                    {
+                        if (end >= buffer.Length) continue;
+                        adjacentWords.Add(new Word(start, end - start + 1));
+                    }
+                }
+
+                // Words after
+                for (int start = endLoc; start >= loc; start--)
+                {
+                    for (int end = start + maxWordSize - 1; end > endLoc; end--)
+                    {
+                        if (end >= buffer.Length) continue;
+                        adjacentWords.Add(new Word(start, end - start + 1));
+                    }
+                }
+
+            }
+            loc = locations[0];
+            endLoc = loc + word.Length - 1;
+            // Contained words
+            for (int start = loc; start <= endLoc; start++)
+            {
+                for (int end = endLoc; end >= start; end--)
+                {
+                    adjacentWords.Add(new Word(start, end - start + 1));
+                }
+            }
+
+            foreach (var adjWord in adjacentWords)
+            {
+                var adjMatches = SA.Search(buffer, buffer.Slice(adjWord.Location, adjWord.Length));
+                var (firstAdjWord, count) = CountWord(adjMatches, adjWord.Length, bitVector);
+                if (count == 0)
+                    this.Counts.Remove(firstAdjWord);
+                else
+                    this.Counts[firstAdjWord] = count;
+            }
+        }
+
+        private (Word, int) CountWord(List<int> matches, int length, BitVector bitVector)
+        {
+            matches.Sort();
+            return CountWord(matches.ToArray(), length, bitVector);
+        }
+
+        private (Word, int) CountWord(int[] sortedMatches, int length, BitVector bitVector)
+        {
+            var count = 0;
+            var lastMatch = - length;
+            for (int i = 0; i < sortedMatches.Length; i++)
+            {
+                var loc = sortedMatches[i];
+                if (loc < lastMatch + length) continue;
+                bool available = true;
+                for (int s = 0; s < length; s++)
+                    if (!bitVector[loc+s]) { available = false; break; }
+                if (available)
+                {
+                    lastMatch = loc;
+                    count += 1;
+                }
+            }
+            return (new Word(sortedMatches[0], length), count);
+        }
+
+        private List<int> Parse(int[] locations, int length, BitVector bitVector)
+        {
+            var results = new List<int>();
+
+            for (int l = 0; l < locations.Length; l++)
+            {
+                var start = locations[l]; // start inclusive
+                var end = locations[l] + length; // end exclusive
+
+                // Check location hasn't been used
+                bool available = true;
+                for (int s = start; s < end; s++)
+                    if (!bitVector[s]) { available = false; break; }
+                if (!available) continue;
+
+                results.Add(start);
+                for (int s = start; s < end; s++)
+                    bitVector[s] = false;
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Transforms/Algorithms/BWD/Entities/BWDStream.cs
+++ b/src/Transforms/Algorithms/BWD/Entities/BWDStream.cs
@@ -58,45 +58,6 @@ namespace BWDPerf.Transforms.Algorithms.BWD.Entities
                 k += offset;
             }
 
-            foreach (var index in stream)
-            {
-                if (index == stoken)
-                {
-                    Console.WriteLine("<s> token");
-                }
-                else
-                {
-                    var word = dictionary[index];
-                    var str = "";
-                    foreach (var symbol in word.Span)
-                    {
-                        str += (char) symbol;
-                    }
-                    Console.WriteLine($"\"{str}\"");
-                }
-            }
-            var s1 = dictionary[stoken];
-            var str1 = "";
-            foreach (var symbol in s1.Span)
-            {
-                if (symbol == 0xff)
-                    str1 += '$';
-                else
-                    str1 += (char) symbol;
-            }
-            Console.WriteLine($"stoken: --- \"{str1}\"");
-            Console.WriteLine("DICT:");
-            for (int i = 0; i < dictionary.Length; i++)
-            {
-                var w = dictionary[i];
-                var sstr = "";
-                foreach (var symbol in w.Span)
-                {
-                    sstr += (char) symbol;
-                }
-                Console.WriteLine($"dict -- \"{sstr}\"");
-            }
-
             this.Stream = stream.ToArray();
         }
     }

--- a/src/Transforms/Algorithms/BWD/Entities/BWDStream.cs
+++ b/src/Transforms/Algorithms/BWD/Entities/BWDStream.cs
@@ -14,48 +14,37 @@ namespace BWDPerf.Transforms.Algorithms.BWD.Entities
 
         public BWDStream(ReadOnlyMemory<byte> buffer, BWDictionary dictionary)
         {
-            // TODO: Use the FM-index to do parsing in O(n)
-            var stoken = dictionary.STokenIndex;
+            // TODO: without s token, we can do parsing in O(n), by finding the first word that matches 
+            // NO TODO: Use the FM-index to do parsing in O(n)
             var data = new int[buffer.Length];
-            int wordCount = 0;
             for (int k = 0; k < data.Length; k++)
-                data[k] = stoken; // Initialize with <s> token
+                data[k] = -1;
 
-            for (int i = 0; i < dictionary.WordCount; i++)
+            for (int i = 0; i < dictionary.Count; i++)
             {
-                if (i == stoken) break; // Don't do this for <s> tokens, they'll be what's left behind
                 var word = dictionary[i];
                 for (int j = 0; j < buffer.Length; j++)
                 {
                     // check if location is used
-                    if (data[j] != stoken) continue;
+                    if (data[j] != -1) continue;
                     if (j + word.Length - 1 >= buffer.Length) break; // can't fit word
                     var match = true;
                     for (int s = 0; s < word.Length; s++)
-                        if (buffer.Span[j + s] != word.Span[s] || data[j+s] != stoken) { match = false; break; }
+                        if (buffer.Span[j + s] != word.Span[s] || data[j+s] != -1) { match = false; break; }
 
                     if (match == true)
                     {
-                        wordCount++;
                         for (int k = 0; k < word.Length; k++)
                             data[j+k] = i;
                     }
                 }
             }
 
-            // var stream = new List<int>(capacity: 2 * wordCount);
             var stream = new List<int>();
             for (int k = 0; k < data.Length;)
             {
                 stream.Add(data[k]);
-                int offset;
-                if (data[k] == stoken)
-                {
-                    for (offset = 0; k+offset >= data.Length ? false : data[k] == data[k+offset]; offset++);
-                }
-                else
-                    offset = dictionary[data[k]].Length;
-                k += offset;
+                k += dictionary[data[k]].Length;
             }
 
             this.Stream = stream.ToArray();

--- a/src/Transforms/Algorithms/BWD/Entities/BWDictionary.cs
+++ b/src/Transforms/Algorithms/BWD/Entities/BWDictionary.cs
@@ -3,62 +3,17 @@ using System.Collections.Generic;
 
 namespace BWDPerf.Transforms.Algorithms.BWD.Entities
 {
-    public class BWDictionary
+    public class BWDictionary : Dictionary<int, ReadOnlyMemory<byte>>
     {
-        private ReadOnlyMemory<byte>[] Dictionary { get; }
-        public int IndexSize { get; }
-        public int Length => this.Dictionary.Length;
-        public int STokenIndex => this.Dictionary.Length - 1;
-        public ReadOnlyMemory<byte> SToken => this.Dictionary[this.STokenIndex];
-        private bool wordCountChanged = true;
-        private int wordCount = 0;
-        public ReadOnlyMemory<byte> this[int index]
-        {
-            get
-            {
-                return this.Dictionary[index];
-            }
-            set
-            {
-                wordCountChanged = true;
-                this.Dictionary[index] = value;
-            }
-        }
-        public int WordCount
-        {
-            get
-            {
-                if (!wordCountChanged) return wordCount;
-                wordCount = 0;
-                for (int i = 0; i < this.Dictionary.Length && this.Dictionary[i].Length > 0; i++)
-                    wordCount++;
-                return wordCount;
-            }
-        }
-
-        public BWDictionary(int indexSize)
-        {
-            this.Dictionary = new ReadOnlyMemory<byte>[1 << indexSize];
-            this.IndexSize = indexSize;
-        }
-
         public ReadOnlyMemory<byte> Serialize()
         {
-            // Precalculate total size so we don't resize the list.
-            int size = 4; // 4 bytes for the dictionary size
-            for (int i = 0; i < this.WordCount; i++)
-                size += this.Dictionary[i].Length;
-
-            var buffer = new List<byte>(capacity: size);
-            buffer.AddRange(BitConverter.GetBytes(this.WordCount));
-            for (int i = 0; i < this.WordCount; i++)
+            var buffer = new List<byte>(capacity: this.Count * 3);
+            buffer.AddRange(BitConverter.GetBytes(this.Count));
+            for (int i = 0; i < this.Count; i++)
             {
-                if (i == this.STokenIndex)
-                    buffer.AddRange(BitConverter.GetBytes(this.Dictionary[i].Length));
-                else
-                    buffer.Add((byte) this.Dictionary[i].Length);
+                buffer.Add((byte) this[i].Length);
 
-                foreach (var symbol in this.Dictionary[i].Span)
+                foreach (var symbol in this[i].Span)
                     buffer.Add(symbol);
             }
             return buffer.ToArray();

--- a/src/Transforms/Algorithms/BWD/Options.cs
+++ b/src/Transforms/Algorithms/BWD/Options.cs
@@ -2,15 +2,13 @@ namespace BWDPerf.Transforms.Algorithms.BWD
 {
     public struct Options
     {
-        public int MaxWordSize { get; set; }
-        public int BPC { get; set; }
-        public int IndexSize { get; set; }
+        public int MaxWordSize { get; }
+        public int BPC { get; }
 
-        public Options(int maxWordSize = 16, int indexSize = 7, int bpc = 8)
+        public Options(int maxWordSize = 16, int bpc = 8)
         {
             this.MaxWordSize = maxWordSize;
             this.BPC = bpc;
-            this.IndexSize = indexSize;
         }
     }
 }

--- a/src/Transforms/Algorithms/BWD/Ranking/NaiveRanking.cs
+++ b/src/Transforms/Algorithms/BWD/Ranking/NaiveRanking.cs
@@ -7,18 +7,16 @@ namespace BWDPerf.Transforms.Algorithms.BWD.Ranking
     public class NaiveRanking : IBWDRanking
     {
         public int BPC { get; }
-        public int IndexSize { get; }
         private RankedWord BestWord { get; set; }
         private readonly RankedWord InitialWord = new RankedWord(new Word(-1, -1), double.MinValue);
         private Dictionary<int, Dictionary<int, double>> LearnedRanks { get; set; }
 
-        public NaiveRanking(int bpc, int indexSize, int maxWordSize)
+        public NaiveRanking(Options options)
         {
-            this.BPC = bpc;
-            this.IndexSize = indexSize;
+            this.BPC = options.BPC;
             this.BestWord = InitialWord;
             this.LearnedRanks = new Dictionary<int, Dictionary<int, double>>();
-            for (int i = 1; i <= maxWordSize; i++)
+            for (int i = 1; i <= options.MaxWordSize; i++)
                 this.LearnedRanks.Add(i, new Dictionary<int, double>());
         }
 
@@ -26,7 +24,7 @@ namespace BWDPerf.Transforms.Algorithms.BWD.Ranking
         {
             if (!this.LearnedRanks[word.Length].TryGetValue(count, out var rank))
             {
-                var calcRank = (word.Length * this.BPC - this.IndexSize) * (count - 1);
+                var calcRank = (word.Length - 1) * (count - 1);
                 this.LearnedRanks[word.Length].Add(count, calcRank);
                 rank = calcRank;
             }

--- a/src/Transforms/Tools/BlockToBytes.cs
+++ b/src/Transforms/Tools/BlockToBytes.cs
@@ -13,7 +13,7 @@ namespace BWDPerf.Transforms.Tools
             {
                 // Write out the dictionary
                 yield return block.Dictionary.Serialize();
-                var bitsPerWord = Convert.ToInt32(Math.Ceiling(Math.Log2(block.Dictionary.WordCount)));
+                var bitsPerWord = Convert.ToInt32(Math.Ceiling(Math.Log2(block.Dictionary.Count)));
 
                 var bytes = new List<byte>();
                 bytes.AddRange(BitConverter.GetBytes(block.Stream.Length));
@@ -51,31 +51,10 @@ namespace BWDPerf.Transforms.Tools
         {
             await foreach (var block in input)
             {
-                int stokenStartIndex = 0;
                 for (int i = 0; i < block.Stream.Length; i++)
                 {
                     var index = block.Stream[i];
-                    if (index != block.Dictionary.STokenIndex)
-                    {
-                        yield return block.Dictionary[index];
-                        continue;
-                    }
-                    var data = new List<byte>();
-                    // TODO: We can use .Slice if we measure which index the current stoken ends at
-                    for (int j = stokenStartIndex; j < block.Dictionary.SToken.Length; j++)
-                    {
-                        if (block.Dictionary.SToken.Span[j] == 0xff)
-                        {
-                            if (j + 1 >= block.Dictionary.SToken.Length) break;
-
-                            if (block.Dictionary.SToken.Span[j + 1] == 0xff)
-                                { data.Add(0xff); j++; }
-                            else
-                                { stokenStartIndex = j + 1; break; }
-                        }
-                        else data.Add(block.Dictionary.SToken.Span[j]);
-                    }
-                    yield return data.ToArray();
+                    yield return block.Dictionary[index];
                 }
             }
         }

--- a/tests/BWDStandaloneTests.cs
+++ b/tests/BWDStandaloneTests.cs
@@ -20,25 +20,17 @@ namespace BWDPerf.Tests
         private const string _decompressedFile = "../../../decompressed";
 
         [TestMethod]
-        public async Task ByteAlignedOneDictionary() =>
-            await RunBWDWithOptions(new Options(indexSize: 8, maxWordSize: 12), 100_000); // 100KB
+        public async Task OneDictionary() =>
+            await RunBWDWithOptions(new Options(maxWordSize: 12), 100_000); // 100KB
 
         [TestMethod]
-        public async Task NotByteAlignedOneDictionary() =>
-            await RunBWDWithOptions(new Options(indexSize: 6, maxWordSize: 12), 100_000); // 100KB
-
-        [TestMethod]
-        public async Task ByteAlignedMultipleDictionaries() =>
-            await RunBWDWithOptions(new Options(indexSize: 8, maxWordSize: 12), 1_000); // 1KB
-
-        [TestMethod]
-        public async Task NotByteAlignedMultipleDictionaries() =>
-            await RunBWDWithOptions(new Options(indexSize: 5, maxWordSize: 12), 1_000); // 1KB
+        public async Task MultipleDictionaries() =>
+            await RunBWDWithOptions(new Options(maxWordSize: 12), 1_000); // 1KB
 
         private async Task RunBWDWithOptions(Options options, int bufferSize)
         {
             var compressTask = new BufferedFileSource(_enwik4, bufferSize)
-                .ToCoder(new BWDEncoder(options, new NaiveRanking(8, options.IndexSize, options.MaxWordSize)))
+                .ToCoder(new BWDEncoder(options, new NaiveRanking(options)))
                 .ToCoder(new BlockToBytes())
                 .Serialize(new SerializeToFile(_compressedFile));
 

--- a/tests/LCPArrayTests.cs
+++ b/tests/LCPArrayTests.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using BWDPerf.Tools;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BWDPerf.Tests
+{
+    // [TestClass]
+    public class LCPArrayTests
+    {
+        // [TestMethod]
+        public void TestString1()
+        {
+            var bytes = ToBytes("mississippi");
+            var SA = new SuffixArray(bytes);
+            var LCP = new LCPArray(bytes, SA);
+            throw new NotImplementedException();
+            // TODO: Write tests for LCP array
+        }
+
+        private byte[] ToBytes(string s) =>
+            s.ToCharArray().Select(c => (byte) c).ToArray();
+    }
+}

--- a/tests/LCPArrayTests.cs
+++ b/tests/LCPArrayTests.cs
@@ -26,15 +26,10 @@ namespace BWDPerf.Tests
             var bytes = ToBytes("Wolloomooloo");
             var SA = new SuffixArray(bytes);
             var LCP = new LCPArray(bytes, SA);
-            SA.Print(bytes);
-            Console.WriteLine($"LCP length: {LCP.Length}");
             var ans = new int[] {0,1,3,0,0,1,2,1,1,2,2};
             Assert.AreEqual(ans.Length, LCP.Length);
             for (int i = 0; i < ans.Length; i++)
-            {
-                Console.WriteLine($"{ans[i]} -- {LCP[i]}");
                 Assert.AreEqual(ans[i], LCP[i]);
-            }
         }
 
         [TestMethod]
@@ -44,7 +39,6 @@ namespace BWDPerf.Tests
             var SA = new SuffixArray(bytes);
             var LCP = new LCPArray(bytes, SA);
             var ans = new int[] {2,3,2,4,4,0,1,3,4,3,5,5,1,4,2,2,1,3,5,3,0,2,4,2};
-            SA.Print(bytes);
             Assert.AreEqual(LCP.Length, ans.Length);
             for (int i = 0; i < ans.Length; i++)
                 Assert.AreEqual(LCP[i], ans[i]);

--- a/tests/LCPArrayTests.cs
+++ b/tests/LCPArrayTests.cs
@@ -5,17 +5,49 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace BWDPerf.Tests
 {
-    // [TestClass]
+    [TestClass]
     public class LCPArrayTests
     {
-        // [TestMethod]
+        [TestMethod]
         public void TestString1()
         {
             var bytes = ToBytes("mississippi");
             var SA = new SuffixArray(bytes);
             var LCP = new LCPArray(bytes, SA);
-            throw new NotImplementedException();
-            // TODO: Write tests for LCP array
+            var ans = new int[] {1,1,4,0,0,1,0,2,1,3};
+            Assert.AreEqual(LCP.Length, ans.Length);
+            for (int i = 0; i < ans.Length; i++)
+                Assert.AreEqual(LCP[i], ans[i]);
+        }
+
+        [TestMethod]
+        public void TestString2()
+        {
+            var bytes = ToBytes("Wolloomooloo");
+            var SA = new SuffixArray(bytes);
+            var LCP = new LCPArray(bytes, SA);
+            SA.Print(bytes);
+            Console.WriteLine($"LCP length: {LCP.Length}");
+            var ans = new int[] {0,1,3,0,0,1,2,1,1,2,2};
+            Assert.AreEqual(ans.Length, LCP.Length);
+            for (int i = 0; i < ans.Length; i++)
+            {
+                Console.WriteLine($"{ans[i]} -- {LCP[i]}");
+                Assert.AreEqual(ans[i], LCP[i]);
+            }
+        }
+
+        [TestMethod]
+        public void TestString3()
+        {
+            var bytes = ToBytes("bababdbabdbbabbdbabbbabdb");
+            var SA = new SuffixArray(bytes);
+            var LCP = new LCPArray(bytes, SA);
+            var ans = new int[] {2,3,2,4,4,0,1,3,4,3,5,5,1,4,2,2,1,3,5,3,0,2,4,2};
+            SA.Print(bytes);
+            Assert.AreEqual(LCP.Length, ans.Length);
+            for (int i = 0; i < ans.Length; i++)
+                Assert.AreEqual(LCP[i], ans[i]);
         }
 
         private byte[] ToBytes(string s) =>

--- a/tests/SuffixArrayTests.cs
+++ b/tests/SuffixArrayTests.cs
@@ -11,34 +11,34 @@ namespace BWDPerf.Tests
         public void TestString1()
         {
             var bytes = ToBytes("mississippi");
-            var sa = new SuffixArray(bytes);
+            var SA = new SuffixArray(bytes);
             var ans = new int[] {10,7,4,1,0,9,8,6,3,5,2};
-            Assert.AreEqual(sa.SA.Length, ans.Length);
+            Assert.AreEqual(SA.Length, ans.Length);
             for (int i = 0; i < ans.Length; i++)
-                Assert.AreEqual(sa.SA[i], ans[i]);
+                Assert.AreEqual(SA[i], ans[i]);
         }
 
         [TestMethod]
         public void TestString2()
         {
             var bytes = ToBytes("Wolloomooloo");
-            var sa = new SuffixArray(bytes);
+            var SA = new SuffixArray(bytes);
             var ans = new int[] {0,2,9,3,6,11,1,8,5,10,7,4};
-            Assert.AreEqual(sa.SA.Length, ans.Length);
+            Assert.AreEqual(SA.Length, ans.Length);
             for (int i = 0; i < ans.Length; i++)
-                Assert.AreEqual(sa.SA[i], ans[i]);
+                Assert.AreEqual(SA[i], ans[i]);
         }
 
         [TestMethod]
         public void TestSearch()
         {
             var bytes = ToBytes("bababdbabdbbabbdbabbbabdb");
-            var sa = new SuffixArray(bytes);
+            var SA = new SuffixArray(bytes);
             var ans = new int[] {1,17,12,21,3,7,24,0,16,11,20,2,6,10,19,18,13,22,14,4,8,23,15,5,9};
-            Assert.AreEqual(sa.SA.Length, ans.Length);
+            Assert.AreEqual(SA.Length, ans.Length);
             for (int i = 0; i < ans.Length; i++)
-                Assert.AreEqual(sa.SA[i], ans[i]);
-            var searchResults = sa.Search(bytes, ToBytes("bb"));
+                Assert.AreEqual(SA[i], ans[i]);
+            var searchResults = SA.Search(bytes, ToBytes("bb"));
             var sr = new int[] {10,13,18,19};
             Assert.AreEqual(searchResults.Length, sr.Length);
             for (int i = 0; i < sr.Length; i++)


### PR DESCRIPTION
Changes:
- use LCP array to make counting easier (less prone to errors in my own code)
- remove the s token (it adds too much complexity and is actually an overhead to compression)
- re-count words instead of counting all of them all over